### PR TITLE
Fix typo in Footprint Resource Type ID

### DIFF
--- a/rcol/rcol_wrapper.py
+++ b/rcol/rcol_wrapper.py
@@ -450,7 +450,7 @@ class OT_S4ANIMTOOLS_ExportFootprint(bpy.types.Operator):
             rcol.chunk_data.append(footprint_chunk)
             rcol.chunk_info.append(ChunkInfo(0, 0))
             new_tgi = TGI()
-            new_tgi.t, new_tgi.g, new_tgi.i = 0xD382BF5, 0x80000000, instance_id.data
+            new_tgi.t, new_tgi.g, new_tgi.i = 0xD382BF57, 0x80000000, instance_id.data
             print(new_tgi)
             footprint_areas = footprint_chunk.footprint_areas
             routing_areas = footprint_chunk.routing_areas


### PR DESCRIPTION
Updated the hex value for Footprint resources in rcol_wrapper.py from 0xD382BF5 to 0xD382BF57. The previous value was missing the final digit, which prevented exported footprints from being correctly recognized as the proper resource type in sims4studio